### PR TITLE
Nopip

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Ansible Collection - jsl6ul.docker_apps
 
 Ansible collection for deploying Docker applications in a rootless environment.
-This collection assumes that you use [jsl6ul.docker_rootless_mode](https://github.com/jsl6ul/docker_rootless_mode) to setup the host and the account to run docker in rootless mode.
-
+This collection assumes that you use [jsl6ul.docker_rootless_mode](https://github.com/jsl6ul/docker_rootless_mode)
+to setup the host and the `docker_rootless_user` account to run docker in rootless mode.
 
 You can use this collection using ansible-galaxy.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,8 @@
 
 Pre-configured ansible roles for applications running in Docker containers.
 
-This collection assumes that you use `jsl6ul.docker_rootless_mode` to setup the host and the account to run docker in rootless mode.
+This collection assumes that you use `jsl6ul.docker_rootless_mode` to setup the host and
+the `docker_rootless_user` account to run docker in rootless mode.
 
 
 # Traefik certificate

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,17 +1,4 @@
 ---
-# non-root user running the containers
-# generate a hash using 'openssl passwd -6' for a SHA512.
-# docker_rootless_user:
-#   name: dockuser
-#   home: /opt/dockuser
-#   shell: /usr/bin/bash
-#   uid: 2222
-#   pw: < password for reference only, not required by the role >
-#   pwhash: < the password hash used by ansible.builtin.user >
-#   authorized_keys: |
-#     pubkey1 set SSH authorized keys
-#     pubkey2 for this account
-
 # main directory for docker apps project. (relative to docker_rootless_home)
 docker_apps_directory: docker
 

--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -1,13 +1,29 @@
 ---
-- name: Rebuild container
-  community.docker.docker_compose:
-    docker_host: "{{ docker_apps_socket }}"
-    project_src: "{{ docker_apps_project }}"
-    build: true
-    restarted: true
+#- name: Rebuild container
+#  community.docker.docker_compose:
+#    docker_host: "{{ docker_apps_socket }}"
+#    project_src: "{{ docker_apps_project }}"
+#    build: true
+#    restarted: true
+#
+#- name: Restart container
+#  community.docker.docker_compose:
+#    docker_host: "{{ docker_apps_socket }}"
+#    project_src: "{{ docker_apps_project }}"
+#    restarted: true
 
-- name: Restart container
-  community.docker.docker_compose:
-    docker_host: "{{ docker_apps_socket }}"
-    project_src: "{{ docker_apps_project }}"
-    restarted: true
+- name: Build container
+  ansible.builtin.shell: |
+    docker compose --project-directory "{{ docker_apps_project }}" build
+
+- name: Stop container
+  ansible.builtin.shell: |
+    docker compose --project-directory "{{ docker_apps_project }}" down
+  listen:
+    - "Restart container"
+
+- name: Start container
+  ansible.builtin.shell: |
+    docker compose --project-directory "{{ docker_apps_project }}" up -d
+  listen:
+    - "Restart container"

--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -1,29 +1,21 @@
 ---
-#- name: Rebuild container
-#  community.docker.docker_compose:
-#    docker_host: "{{ docker_apps_socket }}"
-#    project_src: "{{ docker_apps_project }}"
-#    build: true
-#    restarted: true
-#
-#- name: Restart container
-#  community.docker.docker_compose:
-#    docker_host: "{{ docker_apps_socket }}"
-#    project_src: "{{ docker_apps_project }}"
-#    restarted: true
-
-- name: Build container
+- name: Build containers
   ansible.builtin.shell: |
     docker compose --project-directory "{{ docker_apps_project }}" build
+  listen:
+    - "Rebuild containers"
 
-- name: Stop container
+- name: Stop and remove containers
   ansible.builtin.shell: |
     docker compose --project-directory "{{ docker_apps_project }}" down
   listen:
-    - "Restart container"
+    - "Stop containers"
+    - "Restart containers"
 
-- name: Start container
+- name: Create and start containers
   ansible.builtin.shell: |
     docker compose --project-directory "{{ docker_apps_project }}" up -d
   listen:
-    - "Restart container"
+    - "Start containers"
+    - "Restart containers"
+    - "Rebuild containers"

--- a/roles/freeipa/tasks/fixhttp.yml
+++ b/roles/freeipa/tasks/fixhttp.yml
@@ -31,7 +31,7 @@
 
 - name: "Waiting for service: httpd (max 15min)"
   ansible.builtin.command: |
-    docker exec freeipa_app_1 /usr/bin/systemctl status httpd
+    docker exec freeipa-app-1 /usr/bin/systemctl status httpd
   register: _httpd
   until: _httpd.rc == 0
   retries: 90
@@ -40,6 +40,6 @@
 
 - name: Reload freeipa webserver
   ansible.builtin.command: |
-    docker exec -t freeipa_app_1 systemctl reload httpd
+    docker exec -t freeipa-app-1 systemctl reload httpd
   when: _fixredirect.changed or _fixreferer.changed or force_reload is defined
   changed_when: false

--- a/roles/freeipa/tasks/main.yml
+++ b/roles/freeipa/tasks/main.yml
@@ -18,7 +18,7 @@
     dest: "{{ docker_apps_project }}/docker-compose.yml"
     mode: 0640
 
-- name: Start container
+- name: Start containers
   ansible.builtin.shell: |
     docker compose --project-directory "{{ docker_apps_project }}" up -d
   changed_when: false

--- a/roles/freeipa/tasks/main.yml
+++ b/roles/freeipa/tasks/main.yml
@@ -18,11 +18,10 @@
     dest: "{{ docker_apps_project }}/docker-compose.yml"
     mode: 0640
 
-- name: Deployment (add '-e docker_apps_restart=true' to force-restart)
-  community.docker.docker_compose:
-    docker_host: "{{ docker_apps_socket }}"
-    project_src: "{{ docker_apps_project }}"
-    restarted: "{{ docker_apps_restart | default(false) }}"
+- name: Start container
+  ansible.builtin.shell: |
+    docker compose --project-directory "{{ docker_apps_project }}" up -d
+  changed_when: false
 
 - name: Fix freeipa http on master server
   ansible.builtin.import_tasks: fixhttp.yml

--- a/roles/freeipa/tasks/topologysegment.yml
+++ b/roles/freeipa/tasks/topologysegment.yml
@@ -2,7 +2,7 @@
 - name: Kinit admin
   ansible.builtin.expect:
     echo: false
-    command: docker exec -it freeipa_app_1 /usr/bin/kinit admin
+    command: docker exec -it freeipa-app-1 /usr/bin/kinit admin
     responses:
       (.*)assword for (.*): "{{ freeipa_pwd_admin }}"
   register: _kinit
@@ -10,7 +10,7 @@
 
 - name: Check current domain topology
   ansible.builtin.command: |
-    docker exec -t freeipa_app_1 /usr/bin/ipa topologysegment-find domain {{ freeipa_server_replica1 }}-to-{{ freeipa_server_replica2 }}
+    docker exec -t freeipa-app-1 /usr/bin/ipa topologysegment-find domain {{ freeipa_server_replica1 }}-to-{{ freeipa_server_replica2 }}
   register: _topocheckdomain
   ignore_errors: true
   changed_when: false
@@ -18,13 +18,13 @@
 
 - name: Create domain topology between replicas
   ansible.builtin.command: |
-    docker exec -t freeipa_app_1 /usr/bin/ipa topologysegment-add domain {{ freeipa_server_replica1 }}-to-{{ freeipa_server_replica2 }} --leftnode={{ freeipa_server_replica1 }} --rightnode={{ freeipa_server_replica2 }}
+    docker exec -t freeipa-app-1 /usr/bin/ipa topologysegment-add domain {{ freeipa_server_replica1 }}-to-{{ freeipa_server_replica2 }} --leftnode={{ freeipa_server_replica1 }} --rightnode={{ freeipa_server_replica2 }}
   when: _topocheckdomain.rc != 0
   changed_when: false
 
 - name: Check current ca topology
   ansible.builtin.command: |
-    docker exec -t freeipa_app_1 /usr/bin/ipa topologysegment-find ca {{ freeipa_server_replica1 }}-to-{{ freeipa_server_replica2 }}
+    docker exec -t freeipa-app-1 /usr/bin/ipa topologysegment-find ca {{ freeipa_server_replica1 }}-to-{{ freeipa_server_replica2 }}
   register: _topocheckca
   ignore_errors: true
   changed_when: false
@@ -32,6 +32,6 @@
 
 - name: Create ca topology between replicas
   ansible.builtin.command: |
-    docker exec -t freeipa_app_1 /usr/bin/ipa topologysegment-add ca {{ freeipa_server_replica1 }}-to-{{ freeipa_server_replica2 }} --leftnode={{ freeipa_server_replica1 }} --rightnode={{ freeipa_server_replica2 }}
+    docker exec -t freeipa-app-1 /usr/bin/ipa topologysegment-add ca {{ freeipa_server_replica1 }}-to-{{ freeipa_server_replica2 }} --leftnode={{ freeipa_server_replica1 }} --rightnode={{ freeipa_server_replica2 }}
   when: _topocheckca.rc != 0
   changed_when: false

--- a/roles/freeipa/templates/docker-compose.yml
+++ b/roles/freeipa/templates/docker-compose.yml
@@ -1,6 +1,4 @@
 ---
-version: "2"
-
 networks:
   traefik_proxy:
     external: true

--- a/roles/gitlab/tasks/main.yml
+++ b/roles/gitlab/tasks/main.yml
@@ -14,11 +14,10 @@
     dest: "{{ docker_apps_project }}/docker-compose.yml"
     mode: 0640
 
-- name: Deployment (add '-e docker_apps_restart=true' to force-restart)
-  community.docker.docker_compose:
-    docker_host: "{{ docker_apps_socket }}"
-    project_src: "{{ docker_apps_project }}"
-    restarted: "{{ docker_apps_restart | default(false) }}"
+- name: Start container
+  ansible.builtin.shell: |
+    docker compose --project-directory "{{ docker_apps_project }}" up -d
+  changed_when: false
 
 - name: Copy gitlab runner register script
   ansible.builtin.template:

--- a/roles/gitlab/tasks/main.yml
+++ b/roles/gitlab/tasks/main.yml
@@ -14,7 +14,7 @@
     dest: "{{ docker_apps_project }}/docker-compose.yml"
     mode: 0640
 
-- name: Start container
+- name: Start containers
   ansible.builtin.shell: |
     docker compose --project-directory "{{ docker_apps_project }}" up -d
   changed_when: false

--- a/roles/gitlab/templates/docker-compose.yml
+++ b/roles/gitlab/templates/docker-compose.yml
@@ -1,6 +1,4 @@
 ---
-version: "2.4"
-
 networks:
   traefik_proxy:
     external: true

--- a/roles/glances/tasks/main.yml
+++ b/roles/glances/tasks/main.yml
@@ -14,7 +14,7 @@
     dest: "{{ docker_apps_project }}/docker-compose.yml"
     mode: 0640
 
-- name: Start container
+- name: Start containers
   ansible.builtin.shell: |
     docker compose --project-directory "{{ docker_apps_project }}" up -d
   changed_when: false

--- a/roles/glances/tasks/main.yml
+++ b/roles/glances/tasks/main.yml
@@ -14,8 +14,7 @@
     dest: "{{ docker_apps_project }}/docker-compose.yml"
     mode: 0640
 
-- name: Deployment (add '-e docker_apps_restart=true' to force-restart)
-  community.docker.docker_compose:
-    docker_host: "{{ docker_apps_socket }}"
-    project_src: "{{ docker_apps_project }}"
-    restarted: "{{ docker_apps_restart | default(false) }}"
+- name: Start container
+  ansible.builtin.shell: |
+    docker compose --project-directory "{{ docker_apps_project }}" up -d
+  changed_when: false

--- a/roles/glances/templates/docker-compose.yml
+++ b/roles/glances/templates/docker-compose.yml
@@ -1,6 +1,4 @@
 ---
-version: "2.4"
-
 networks:
   traefik_proxy:
     external: true

--- a/roles/graylog/tasks/main.yml
+++ b/roles/graylog/tasks/main.yml
@@ -21,8 +21,7 @@
     mode: 0644
   notify: Restart container
 
-- name: Deployment (add '-e docker_apps_restart=true' to force-restart)
-  community.docker.docker_compose:
-    docker_host: "{{ docker_apps_socket }}"
-    project_src: "{{ docker_apps_project }}"
-    restarted: "{{ docker_apps_restart | default(false) }}"
+- name: Start container
+  ansible.builtin.shell: |
+    docker compose --project-directory "{{ docker_apps_project }}" up -d
+  changed_when: false

--- a/roles/graylog/tasks/main.yml
+++ b/roles/graylog/tasks/main.yml
@@ -19,7 +19,7 @@
     dest: "{{ docker_apps_project }}/graylog.conf"
     content: "{{ graylog_conf_file }}"
     mode: 0644
-  notify: Restart container
+  notify: Restart containers
 
 - name: Start container
   ansible.builtin.shell: |

--- a/roles/graylog/tasks/main.yml
+++ b/roles/graylog/tasks/main.yml
@@ -21,7 +21,7 @@
     mode: 0644
   notify: Restart containers
 
-- name: Start container
+- name: Start containers
   ansible.builtin.shell: |
     docker compose --project-directory "{{ docker_apps_project }}" up -d
   changed_when: false

--- a/roles/graylog/templates/docker-compose.yml
+++ b/roles/graylog/templates/docker-compose.yml
@@ -98,7 +98,6 @@ services:
       traefik.enable: "true"
       traefik.docker.network: "traefik_proxy"
       traefik.http.routers.graylog.rule: "Host(`{{ traefik_address_graylog }}`)"
-      traefik.http.routers.graylog.tls.domains[0].main: "{{ traefik_address_graylog }}"
 {% if docker_apps_traefik_tls %}
       traefik.http.routers.graylog.tls: "true"
 {% endif %}

--- a/roles/graylog/templates/docker-compose.yml
+++ b/roles/graylog/templates/docker-compose.yml
@@ -1,6 +1,4 @@
 ---
-version: '2'
-
 volumes:
   mongo:
   opensearch:

--- a/roles/homepage/tasks/main.yml
+++ b/roles/homepage/tasks/main.yml
@@ -42,7 +42,7 @@
     mode: 0644
   notify: Restart containers
 
-- name: Start container
+- name: Start containers
   ansible.builtin.shell: |
     docker compose --project-directory "{{ docker_apps_project }}" up -d
   changed_when: false

--- a/roles/homepage/tasks/main.yml
+++ b/roles/homepage/tasks/main.yml
@@ -19,28 +19,28 @@
     dest: "{{ docker_apps_project }}/settings.yaml"
     content: "{{ homepage_settings_yaml }}"
     mode: 0644
-  notify: Restart container
+  notify: Restart containers
 
 - name: Copy bookmarks file
   ansible.builtin.copy:
     dest: "{{ docker_apps_project }}/bookmarks.yaml"
     content: "{{ homepage_bookmarks_yaml }}"
     mode: 0644
-  notify: Restart container
+  notify: Restart containers
 
 - name: Copy services file
   ansible.builtin.copy:
     dest: "{{ docker_apps_project }}/services.yaml"
     content: "{{ homepage_services_yaml }}"
     mode: 0644
-  notify: Restart container
+  notify: Restart containers
 
 - name: Copy widgets file
   ansible.builtin.copy:
     dest: "{{ docker_apps_project }}/widgets.yaml"
     content: "{{ homepage_widgets_yaml }}"
     mode: 0644
-  notify: Restart container
+  notify: Restart containers
 
 - name: Start container
   ansible.builtin.shell: |

--- a/roles/homepage/tasks/main.yml
+++ b/roles/homepage/tasks/main.yml
@@ -42,8 +42,7 @@
     mode: 0644
   notify: Restart container
 
-- name: Deployment (add '-e docker_apps_restart=true' to force-restart)
-  community.docker.docker_compose:
-    docker_host: "{{ docker_apps_socket }}"
-    project_src: "{{ docker_apps_project }}"
-    restarted: "{{ docker_apps_restart | default(false) }}"
+- name: Start container
+  ansible.builtin.shell: |
+    docker compose --project-directory "{{ docker_apps_project }}" up -d
+  changed_when: false

--- a/roles/homepage/templates/docker-compose.yml
+++ b/roles/homepage/templates/docker-compose.yml
@@ -1,5 +1,4 @@
 ---
-version: "2.4"
 networks:
   traefik_proxy:
     external: true

--- a/roles/mirror_deb/README.md
+++ b/roles/mirror_deb/README.md
@@ -11,6 +11,3 @@ This container downloads and maintains a partial local Debian/Ubuntu mirror usin
 - https://manpages.org/debmirror
 - https://salsa.debian.org/debian/debmirror
 
-## Rebuild
-
-The `Rebuild container` handler doesn't seem to work. You should run `docker compose build` manually.

--- a/roles/mirror_deb/tasks/main.yml
+++ b/roles/mirror_deb/tasks/main.yml
@@ -33,22 +33,20 @@
   ansible.builtin.copy:
     dest: "{{ docker_apps_project }}/Dockerfile"
     content: "{{ mirror_deb_dockerfile }}"
-  #notify: Rebuild container
 
 - name: Copy entrypoint.sh
   ansible.builtin.copy:
     dest: "{{ docker_apps_project }}/entrypoint.sh"
     content: "{{ mirror_deb_entrypoint }}"
-  #notify: Rebuild container
+  notify: Build container
 
 - name: Copy nginx.conf
   ansible.builtin.copy:
     dest: "{{ docker_apps_project }}/nginx.conf"
     content: "{{ mirror_deb_nginx_conf }}"
-  #notify: Rebuild container
+  notify: Build container
 
-- name: Deployment (add '-e docker_apps_restart=true' to force-restart)
-  community.docker.docker_compose:
-    docker_host: "{{ docker_apps_socket }}"
-    project_src: "{{ docker_apps_project }}"
-    restarted: "{{ docker_apps_restart | default(false) }}"
+- name: Start container
+  ansible.builtin.shell: |
+    docker compose --project-directory "{{ docker_apps_project }}" up -d
+  changed_when: false

--- a/roles/mirror_deb/tasks/main.yml
+++ b/roles/mirror_deb/tasks/main.yml
@@ -33,6 +33,7 @@
   ansible.builtin.copy:
     dest: "{{ docker_apps_project }}/Dockerfile"
     content: "{{ mirror_deb_dockerfile }}"
+  notify: Rebuild containers
 
 - name: Copy entrypoint.sh
   ansible.builtin.copy:

--- a/roles/mirror_deb/tasks/main.yml
+++ b/roles/mirror_deb/tasks/main.yml
@@ -46,7 +46,7 @@
     content: "{{ mirror_deb_nginx_conf }}"
   notify: Rebuild containers
 
-- name: Start container
+- name: Start containers
   ansible.builtin.shell: |
     docker compose --project-directory "{{ docker_apps_project }}" up -d
   changed_when: false

--- a/roles/mirror_deb/tasks/main.yml
+++ b/roles/mirror_deb/tasks/main.yml
@@ -38,13 +38,13 @@
   ansible.builtin.copy:
     dest: "{{ docker_apps_project }}/entrypoint.sh"
     content: "{{ mirror_deb_entrypoint }}"
-  notify: Build container
+  notify: Rebuild containers
 
 - name: Copy nginx.conf
   ansible.builtin.copy:
     dest: "{{ docker_apps_project }}/nginx.conf"
     content: "{{ mirror_deb_nginx_conf }}"
-  notify: Build container
+  notify: Rebuild containers
 
 - name: Start container
   ansible.builtin.shell: |

--- a/roles/mirror_deb/templates/docker-compose.yml
+++ b/roles/mirror_deb/templates/docker-compose.yml
@@ -1,6 +1,4 @@
 ---
-version: "2.4"
-
 volumes:
   homeroot:
 

--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -14,7 +14,7 @@
     dest: "{{ docker_apps_project }}/docker-compose.yml"
     mode: 0640
 
-- name: Ccopy prometheus.yml
+- name: Copy prometheus.yml
   ansible.builtin.copy:
     content: "{{ prometheus_yml }}"
     dest: "{{ docker_apps_project }}/prometheus.yml"
@@ -69,8 +69,7 @@
     mode: 0640
   notify: Restart container
 
-- name: Deployment (add '-e docker_apps_restart=true' to force-restart)
-  community.docker.docker_compose:
-    docker_host: "{{ docker_apps_socket }}"
-    project_src: "{{ docker_apps_project }}"
-    restarted: "{{ docker_apps_restart | default(false) }}"
+- name: Start container
+  ansible.builtin.shell: |
+    docker compose --project-directory "{{ docker_apps_project }}" up -d
+  changed_when: false

--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -69,7 +69,7 @@
     mode: 0640
   notify: Restart containers
 
-- name: Start container
+- name: Start containers
   ansible.builtin.shell: |
     docker compose --project-directory "{{ docker_apps_project }}" up -d
   changed_when: false

--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -19,55 +19,55 @@
     content: "{{ prometheus_yml }}"
     dest: "{{ docker_apps_project }}/prometheus.yml"
     mode: 0644
-  notify: Restart container
+  notify: Restart containers
 
 - name: Copy prometheus_alerts.yml"
   ansible.builtin.copy:
     content: "{{ prometheus_alerts_yml }}"
     dest: "{{ docker_apps_project }}/prometheus_alerts.yml"
     mode: 0644
-  notify: Restart container
+  notify: Restart containers
 
 - name: Copy alertmanager.yml
   ansible.builtin.copy:
     content: "{{ alertmanager_yml }}"
     dest: "{{ docker_apps_project }}/alertmanager.yml"
     mode: 0644
-  notify: Restart container
+  notify: Restart containers
 
 - name: Copy blackbox_config.yml
   ansible.builtin.copy:
     content: "{{ blackbox_config_yml }}"
     dest: "{{ docker_apps_project }}/blackbox_config.yml"
     mode: 0644
-  notify: Restart container
+  notify: Restart containers
 
 - name: Copy grafana_datasources.yml
   ansible.builtin.copy:
     content: "{{ grafana_datasources_yml }}"
     dest: "{{ docker_apps_project }}/grafana_datasources.yml"
     mode: 0644
-  notify: Restart container
+  notify: Restart containers
 
 - name: Copy grafana_providers.yml
   ansible.builtin.copy:
     content: "{{ grafana_providers_yml }}"
     dest: "{{ docker_apps_project }}/grafana_providers.yml"
     mode: 0644
-  notify: Restart container
+  notify: Restart containers
 
 - name: Copy grafana dashboards
   ansible.builtin.copy:
     src: grafana_dashboards
     dest: "{{ docker_apps_project }}/"
-  notify: Restart container
+  notify: Restart containers
 
 - name: Copy grafana.env
   ansible.builtin.copy:
     content: "{{ grafana_env }}"
     dest: "{{ docker_apps_project }}/grafana.env"
     mode: 0640
-  notify: Restart container
+  notify: Restart containers
 
 - name: Start container
   ansible.builtin.shell: |

--- a/roles/monitoring/templates/docker-compose.yml
+++ b/roles/monitoring/templates/docker-compose.yml
@@ -1,6 +1,4 @@
 ---
-version: "2.4"
-
 volumes:
   alertmanager:
   grafana_plugins:

--- a/roles/portainer/tasks/main.yml
+++ b/roles/portainer/tasks/main.yml
@@ -20,7 +20,7 @@
     dest: "{{ docker_apps_project }}/admin.pass"
     mode: 0640
   when: portainer_admin_password is defined
-  notify: Restart container
+  notify: Restart containers
 
 - name: Start container
   ansible.builtin.shell: |

--- a/roles/portainer/tasks/main.yml
+++ b/roles/portainer/tasks/main.yml
@@ -20,9 +20,9 @@
     dest: "{{ docker_apps_project }}/admin.pass"
     mode: 0640
   when: portainer_admin_password is defined
+  notify: Restart container
 
-- name: Deployment (add '-e docker_apps_restart=true' to force-restart)
-  community.docker.docker_compose:
-    docker_host: "{{ docker_apps_socket }}"
-    project_src: "{{ docker_apps_project }}"
-    restarted: "{{ docker_apps_restart | default(false) }}"
+- name: Start container
+  ansible.builtin.shell: |
+    docker compose --project-directory "{{ docker_apps_project }}" up -d
+  changed_when: false

--- a/roles/portainer/tasks/main.yml
+++ b/roles/portainer/tasks/main.yml
@@ -22,7 +22,7 @@
   when: portainer_admin_password is defined
   notify: Restart containers
 
-- name: Start container
+- name: Start containers
   ansible.builtin.shell: |
     docker compose --project-directory "{{ docker_apps_project }}" up -d
   changed_when: false

--- a/roles/portainer/templates/docker-compose.yml
+++ b/roles/portainer/templates/docker-compose.yml
@@ -1,6 +1,4 @@
 ---
-version: "2.4"
-
 networks:
   traefik_proxy:
     external: true

--- a/roles/privatebin/tasks/main.yml
+++ b/roles/privatebin/tasks/main.yml
@@ -14,7 +14,7 @@
     dest: "{{ docker_apps_project }}/docker-compose.yml"
     mode: 0640
 
-- name: Start container
+- name: Start containers
   ansible.builtin.shell: |
     docker compose --project-directory "{{ docker_apps_project }}" up -d
   changed_when: false

--- a/roles/privatebin/tasks/main.yml
+++ b/roles/privatebin/tasks/main.yml
@@ -14,8 +14,7 @@
     dest: "{{ docker_apps_project }}/docker-compose.yml"
     mode: 0640
 
-- name: Deployment (add '-e docker_apps_restart=true' to force-restart)
-  community.docker.docker_compose:
-    docker_host: "{{ docker_apps_socket }}"
-    project_src: "{{ docker_apps_project }}"
-    restarted: "{{ docker_apps_restart | default(false) }}"
+- name: Start container
+  ansible.builtin.shell: |
+    docker compose --project-directory "{{ docker_apps_project }}" up -d
+  changed_when: false

--- a/roles/privatebin/templates/docker-compose.yml
+++ b/roles/privatebin/templates/docker-compose.yml
@@ -1,5 +1,4 @@
-version: "2"
-
+---
 networks:
   traefik_proxy:
     external: true

--- a/roles/traefik/defaults/main.yml
+++ b/roles/traefik/defaults/main.yml
@@ -28,8 +28,10 @@ traefik_envvar_file: |
   TRAEFIK_ENTRYPOINTS_ldap_ADDRESS=:389
   TRAEFIK_ENTRYPOINTS_ldaps=true
   TRAEFIK_ENTRYPOINTS_ldaps_ADDRESS=:636
+  {% if docker_apps_traefik_serversTransports is defined %}
   # file provider directory
   TRAEFIK_PROVIDERS_FILE_DIRECTORY=/etc/traefik
+  {% endif %}
   {% if docker_apps_traefik_certresolver != "none" %}
   # cert resolver settings
   {{ docker_apps_traefik_certresolver_settings }}

--- a/roles/traefik/tasks/main.yml
+++ b/roles/traefik/tasks/main.yml
@@ -19,6 +19,7 @@
     dest: "{{ docker_apps_project }}/traefik.env"
     content: "{{ traefik_envvar_file }}"
     mode: 0640
+  notify: Restart container
 
 - name: Create traefik serverTransports file
   ansible.builtin.copy:
@@ -32,9 +33,9 @@
   when:
     - docker_apps_traefik_tls
     - docker_apps_traefik_certresolver == "none"
+  notify: Restart container
 
-- name: Deployment (add '-e docker_apps_restart=true' to force-restart)
-  community.docker.docker_compose:
-    docker_host: "{{ docker_apps_socket }}"
-    project_src: "{{ docker_apps_project }}"
-    restarted: "{{ docker_apps_restart | default(false) }}"
+- name: Start container
+  ansible.builtin.shell: |
+    docker compose --project-directory "{{ docker_apps_project }}" up -d
+  changed_when: false

--- a/roles/traefik/tasks/main.yml
+++ b/roles/traefik/tasks/main.yml
@@ -35,7 +35,7 @@
     - docker_apps_traefik_certresolver == "none"
   notify: Restart containers
 
-- name: Start container
+- name: Start containers
   ansible.builtin.shell: |
     docker compose --project-directory "{{ docker_apps_project }}" up -d
   changed_when: false

--- a/roles/traefik/tasks/main.yml
+++ b/roles/traefik/tasks/main.yml
@@ -19,21 +19,21 @@
     dest: "{{ docker_apps_project }}/traefik.env"
     content: "{{ traefik_envvar_file }}"
     mode: 0640
-  notify: Restart container
+  notify: Restart containers
 
 - name: Create traefik serverTransports file
   ansible.builtin.copy:
     dest: "{{ docker_apps_project }}/serversTransports.yml"
     content: "{{ docker_apps_traefik_serversTransports }}"
   when: docker_apps_traefik_serversTransports is defined
-  notify: Restart container
+  notify: Restart containers
 
 - name: Import certificate.yml
   ansible.builtin.import_tasks: certificate.yml
   when:
     - docker_apps_traefik_tls
     - docker_apps_traefik_certresolver == "none"
-  notify: Restart container
+  notify: Restart containers
 
 - name: Start container
   ansible.builtin.shell: |

--- a/roles/traefik/templates/docker-compose.yml
+++ b/roles/traefik/templates/docker-compose.yml
@@ -1,6 +1,4 @@
 ---
-version: "2.4"
-
 volumes:
   data:
 


### PR DESCRIPTION
Replace all community.docker.docker_compose with ansible.builtin.shell.

docker-compose has been rewritten and the ansible module is broken.
There is a migration from docker_compose V1 to V2, but transitions bring
their own problems. For the time being, using 'docker compose' with
'ansible.builtin.shell', is pretty straightforward, and it avoids all
the problems of configuring pip constraints for pyyaml, cython & the
break-system-packages stuff.
