### PR TITLE
update roles/freeipa/

### DIFF
--- a/roles/freeipa/defaults/main.yml
+++ b/roles/freeipa/defaults/main.yml
@@ -1,13 +1,11 @@
 ---
-freeipa_docker_image: "docker.io/freeipa/freeipa-server:rocky-9-4.10.1"
+# freeipa_docker_image: "docker.io/freeipa/freeipa-server:rocky-9-4.10.1"
+freeipa_docker_image: "docker.io/freeipa/freeipa-server:almalinux-9-4.11.0"
 
 freeipa_dns_servers:
   - 1.1.1.1
   - 8.8.8.8
   - 9.9.9.9
-
-# disable cgroup v2 pour freeipa
-docker_rootless_cgroupv2: false
 
 # freeipa directory server/manager password
 # freeipa_pwd_dm: <secret>
@@ -80,10 +78,10 @@ common_traefik_serversTransports: |
 
 # freeipa installation commands
 freeipa_command_master: |
-  ipa-server-install --admin-password='{{ freeipa_pwd_admin }}' --ds-password='{{ freeipa_pwd_dm }}' --domain={{ freeipa_realm }} --realm={{ freeipa_realm | upper }} --unattended --no-hbac-allow --no-ntp
+  ipa-server-install --admin-password='{{ freeipa_pwd_admin }}' --ds-password='{{ freeipa_pwd_dm }}' --domain={{ freeipa_realm }} --realm={{ freeipa_realm | upper }} --unattended --no-hbac-allow --no-ntp --skip-mem-check
 
 freeipa_command_replica: |
-  ipa-replica-install --admin-password='{{ freeipa_pwd_admin }}' --domain={{ freeipa_domain }} --realm={{ freeipa_realm | upper }} --server={{ freeipa_server_master }} --hostname={{ freeipa_hostname }}.{{ common_apps_domain }} --unattended --no-ntp --setup-ca
+  ipa-replica-install --admin-password='{{ freeipa_pwd_admin }}' --domain={{ freeipa_domain }} --realm={{ freeipa_realm | upper }} --server={{ freeipa_server_master }} --hostname={{ freeipa_hostname }}.{{ common_apps_domain }} --unattended --no-ntp --setup-ca --skip-mem-check
 
 # if you have a "real" certificate, you need to add the following parameters to the above commands.
 # (it should works, but I didn't test it)

--- a/roles/freeipa/tasks/main.yml
+++ b/roles/freeipa/tasks/main.yml
@@ -1,8 +1,4 @@
 ---
-- name: "Check required cgroup v1 (failed? set docker_rootless_cgroupv2: false, run docker_rootless_mode & reboot)"
-  ansible.builtin.shell: fgrep cgroup_hierarchy=0 /proc/cmdline
-  changed_when: false
-
 - name: Set project directory
   ansible.builtin.set_fact:
     docker_project_dir: "{{ common_apps_directory }}/{{ role_name }}"

--- a/roles/freeipa/templates/docker-compose.yml
+++ b/roles/freeipa/templates/docker-compose.yml
@@ -28,6 +28,7 @@ services:
     dns: {{ freeipa_dns_servers }}
     ports: {{ freeipa_ports }}
     mem_limit: 2048M
+    cgroup: host
     environment:
       TZ: "America/New_York"
       PHP_TZ: "America/New_York"
@@ -37,6 +38,7 @@ services:
       - "data:/data"
       - "python:/usr/lib/python3.9/site-packages/ipaserver"
       - "/sys/fs/cgroup:/sys/fs/cgroup:ro"
+      - "/sys/fs/cgroup/user.slice/user-{{ docker_rootless_user.uid }}.slice/user@{{ docker_rootless_user.uid }}.service:/sys/fs/cgroup/user.slice/user-{{ docker_rootless_user.uid }}.slice/user@{{ docker_rootless_user.uid }}.service:rw"
       - "/etc/localtime:/etc/localtime:ro"
 {% if freeipa_cert is defined %}
       - "./freeipa_cert.crt:/etc/pki/CA/certs/freeipa_cert.crt:ro"


### PR DESCRIPTION
update for freeipa in rootless container with cgroup v2

- set freeipa_docker_image: "docker.io/freeipa/freeipa-server:almalinux-9-4.11.0"
- remove docker_rootless_cgroupv2: false
- add '--skip-mem-check' to 'freeipa_command_master' and 'freeipa_command_replica'
- remove task: "Check required cgroup v1 (failed? set docker_rootless_cgroupv2: false, run docker_rootless_mode & reboot)"
- update docker-compose.yml
  - add 'cgroup: host'
  - add volume for "/sys/fs/cgroup/user.slice/user..."
- update README.md