### PR TITLE
update roles/monitoring/

### DIFF
--- a/roles/monitoring/defaults/main.yml
+++ b/roles/monitoring/defaults/main.yml
@@ -27,6 +27,28 @@ monitoring_prometheus_retention_time: "365d"
 # Passwords must be hashed using MD5, SHA1, or BCrypt.
 # monitoring_alertmanager_basicauth: "test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/,test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0"
 
+# Volumes
+monitoring_prometheus_volumes:
+  - "./prometheus.yml:/etc/prometheus/prometheus.yml"
+  - "./prometheus_alerts.yml:/etc/prometheus/alerts.yml"
+  - "prometheus:/prometheus"
+
+monitoring_alertmanager_volumes:
+  - "./alertmanager.yml:/etc/alertmanager/alertmanager.yml"
+  - "alertmanager:/alertmanager"
+
+monitoring_blackbox_volumes:
+  - "./blackbox_config.yml:/etc/blackbox_exporter/config.yml"
+
+monitoring_grafana_volumes:
+  - "./grafana_dashboards:/var/lib/grafana/dashboards/"
+  - "./grafana_datasources.yml:/etc/grafana/provisioning/datasources/datasources.yml"
+  - "./grafana_providers.yml:/etc/grafana/provisioning/dashboards/providers.yml"
+  - "grafana_plugins:/var/lib/grafana/plugins/"
+
+# Grafana plugins to install
+monitoring_grafana_install_plugins: "grafana-piechart-panel,vonage-status-panel"
+
 # alertmanager.yml
 monitoring_alertmanager_yml: |
   global:
@@ -129,7 +151,7 @@ monitoring_grafana_env: |
   GF_SECURITY_ADMIN_PASSWORD={{ monitoring_grafana_admin_password }}
   GF_SERVER_ROOT_URL=http://localhost:3000
   GF_SMTP_ENABLED=false
-  GF_INSTALL_PLUGINS=grafana-piechart-panel,vonage-status-panel
+  GF_INSTALL_PLUGINS={{ monitoring_grafana_install_plugins }}
   GF_AUTH_ANONYMOUS_ENABLED=true
   GF_AUTH_ANONYMOUS_ORG_NAME=Main Org.
   GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer

--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -66,8 +66,8 @@
 
 - name: Copy grafana dashboards
   ansible.builtin.copy:
-    src: grafana_dashboards
-    dest: "{{ docker_project_dir }}/"
+    src: grafana_dashboards/
+    dest: "{{ docker_project_dir }}/grafana_dashboards/ansible"
   notify: Restart containers
 
 - name: Copy grafana.env

--- a/roles/monitoring/templates/docker-compose.yml
+++ b/roles/monitoring/templates/docker-compose.yml
@@ -3,7 +3,6 @@ volumes:
   alertmanager:
   grafana_plugins:
   prometheus:
-  grafana_dashboards:
 
 networks:
   default:
@@ -25,9 +24,7 @@ services:
     mem_limit: 512M
     volumes:
       - "/etc/localtime:/etc/localtime:ro"
-      - "./prometheus.yml:/etc/prometheus/prometheus.yml"
-      - "./prometheus_alerts.yml:/etc/prometheus/alerts.yml"
-      - "prometheus:/prometheus"
+      {{ monitoring_prometheus_volumes|to_nice_yaml|indent(6) }}
     environment:
       TZ: "America/New_York"
       PHP_TZ: "America/New_York"
@@ -37,6 +34,7 @@ services:
     labels:
       traefik.enable: "true"
       traefik.docker.network: "traefik_proxy"
+      traefik.http.routers.prometheus.entrypoints: "http, https"
       traefik.http.routers.prometheus.rule: "Host(`{{ monitoring_prometheus_traefik_address }}`)"
       traefik.http.services.prometheus.loadbalancer.server.port: "9090"
 {% if monitoring_prometheus_basicauth is defined %}
@@ -66,14 +64,14 @@ services:
     mem_limit: 512M
     volumes:
       - "/etc/localtime:/etc/localtime:ro"
-      - "./alertmanager.yml:/etc/alertmanager/alertmanager.yml"
-      - "alertmanager:/alertmanager"
+      {{ monitoring_alertmanager_volumes|to_nice_yaml|indent(6) }}
     environment:
       TZ: "America/New_York"
       PHP_TZ: "America/New_York"
     labels:
       traefik.enable: "true"
       traefik.docker.network: "traefik_proxy"
+      traefik.http.routers.alertmanager.entrypoints: "http, https"
       traefik.http.routers.alertmanager.rule: "Host(`{{ monitoring_alertmanager_traefik_address }}`)"
       traefik.http.services.alertmanager.loadbalancer.server.port: "9093"
 {% if monitoring_alertmanager_basicauth is defined %}
@@ -102,13 +100,14 @@ services:
     mem_limit: 512M
     volumes:
       - "/etc/localtime:/etc/localtime:ro"
-      - "./blackbox_config.yml:/etc/blackbox_exporter/config.yml"
+      {{ monitoring_blackbox_volumes|to_nice_yaml|indent(6) }}
     environment:
       TZ: "America/New_York"
       PHP_TZ: "America/New_York"
     labels:
       traefik.enable: "true"
       traefik.docker.network: "traefik_proxy"
+      traefik.http.routers.blackbox.entrypoints: "http, https"
       traefik.http.routers.blackbox.rule: "Host(`{{ monitoring_blackbox_traefik_address }}`)"
       traefik.http.services.blackbox.loadbalancer.server.port: "9115"
 {% if common_traefik_tls %}
@@ -132,14 +131,10 @@ services:
     mem_limit: 512M
     volumes:
       - "/etc/localtime:/etc/localtime:ro"
-      - "grafana_dashboards:/var/lib/grafana/dashboards/"
-      - "grafana_plugins:/var/lib/grafana/plugins/"
-      - "./grafana_providers.yml:/etc/grafana/provisioning/dashboards/providers.yml"
-      - "./grafana_datasources.yml:/etc/grafana/provisioning/datasources/datasources.yml"
+      {{ monitoring_grafana_volumes|to_nice_yaml|indent(6) }}
 {% if monitoring_grafana_ldap_toml is defined %}
       - "./grafana_ldap.toml:/etc/grafana/ldap.toml"
 {% endif %}
-      - "./grafana_dashboards:/var/lib/grafana/dashboards/ansible/"
     environment:
       TZ: "America/New_York"
       PHP_TZ: "America/New_York"
@@ -148,6 +143,7 @@ services:
     labels:
       traefik.enable: "true"
       traefik.docker.network: "traefik_proxy"
+      traefik.http.routers.grafana.entrypoints: "http, https"
       traefik.http.routers.grafana.rule: "Host(`{{ monitoring_grafana_traefik_address }}`)"
       traefik.http.services.grafana.loadbalancer.server.port: "3000"
 {% if common_traefik_tls %}


### PR DESCRIPTION
- add variables to define container volumes:
  - monitoring_prometheus_volumes
  - monitoring_alertmanager_volumes
  - monitoring_blackbox_volumes
  - monitoring_grafana_volumes
- add 'monitoring_grafana_install_plugins' to define the list of plugins to install.
- change destination path in 'Copy grafana dashboards' task to 'ansible' subdirectory.
- remove unused volume 'grafana_dashboards'
- fix docker-compose.yml, add all 'traefik.http.routers.*.entrypoints: "http, https"'