### PR TITLE
update roles/freeipa/

### DIFF
--- a/roles/freeipa/defaults/main.yml
+++ b/roles/freeipa/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-# freeipa_docker_image: "docker.io/freeipa/freeipa-server:rocky-9-4.10.1"
 freeipa_docker_image: "docker.io/freeipa/freeipa-server:almalinux-9-4.11.0"
 
 freeipa_dns_servers:

--- a/roles/freeipa/tasks/fixhttp.yml
+++ b/roles/freeipa/tasks/fixhttp.yml
@@ -11,10 +11,14 @@
     replace: "{{ item.replace }}"
     backup: true
   with_items:
-    - { regexp: ^(RewriteRule \^/\$) (https://.*)(/ipa/ui.*)$, replace: \1 \3 }
-    - { regexp: ^(RewriteRule \^\/ipa\/\(.*)$, replace: "#\\1" }
-    - { regexp: ^(RewriteRule \^\/\(.*)$, replace: "#\\1" }
-    - { regexp: ^(RewriteCond .*)$, replace: "#\\1" }
+    - regexp: ^(RewriteRule \^/\$) (https://.*)(/ipa/ui.*)$
+      replace: \1 \3
+    - regexp: ^(RewriteRule \^\/ipa\/\(.*)$
+      replace: "#\\1"
+    - regexp: ^(RewriteRule \^\/\(.*)$
+      replace: "#\\1"
+    - regexp: ^(RewriteCond .*)$
+      replace: "#\\1"
   register: _fixredirect
 
 - name: "Waiting for file: rpcserver.py (max 15min)"
@@ -22,11 +26,18 @@
     path: "{{ ansible_env.HOME }}/.local/share/docker/volumes/freeipa_python/_data/rpcserver.py"
     timeout: 900
 
-- name: Deactivate HTTP RefererError
+- name: Disable HTTP referer checks
   ansible.builtin.replace:
     path: "{{ ansible_env.HOME }}/.local/share/docker/volumes/freeipa_python/_data/rpcserver.py"
-    regexp: ^([ ]*)(return self.marshal\(result, RefererError\(referer.*)$
-    replace: "\\1pass  # \\2"
+    regexp: "{{ item.regexp }}"
+    replace: "{{ item.replace }}"
+  with_items:
+    - regexp: ^([ ]*)(return self.marshal\(result\, RefererError\(referer.*)$
+      replace: "\\1pass  # \\2"
+    - regexp: ^([ ]*)(if not self.check_referer\(environ\)\:)$
+      replace: "\\1# \\2"
+    - regexp: ^([ ]*)(return self.bad_request\(environ\, start_response\, 'denied'\))$
+      replace: "\\1# \\2"
   register: _fixreferer
 
 - name: "Waiting for service: httpd (max 15min)"

--- a/roles/freeipa/tasks/main.yml
+++ b/roles/freeipa/tasks/main.yml
@@ -22,17 +22,21 @@
 - name: Flush handlers
   meta: flush_handlers
 
-- name: Fix freeipa http on master server
+- name: Patch freeipa for traefik on master server
   ansible.builtin.import_tasks: fixhttp.yml
-  when: freeipa_role == "master"
+  when:
+    - freeipa_role == "master"
+    - freeipa_traefik
 
-- name: Fix freeipa http on replica servers
+- name: Patch freeipa for traefik on replica servers
   ansible.builtin.import_tasks: fixhttp.yml
-  when: freeipa_role == "replica"
+  when:
+    - freeipa_role == "replica"
+    - freeipa_traefik
 
 - name: Set replication between servers
   ansible.builtin.import_tasks: topologysegment.yml
+  run_once: true
   when:
     - freeipa_server_replica1 is defined
     - freeipa_server_replica2 is defined
-    - freeipa_role == "master"

--- a/roles/freeipa/tasks/topologysegment.yml
+++ b/roles/freeipa/tasks/topologysegment.yml
@@ -7,6 +7,7 @@
       (.*)assword for (.*): "{{ freeipa_pwd_admin }}"
   register: _kinit
   changed_when: false
+  no_log: true
 
 - name: Check current domain topology
   ansible.builtin.command: |
@@ -21,6 +22,7 @@
     docker exec -t freeipa-app-1 /usr/bin/ipa topologysegment-add domain {{ freeipa_server_replica1 }}-to-{{ freeipa_server_replica2 }} --leftnode={{ freeipa_server_replica1 }} --rightnode={{ freeipa_server_replica2 }}
   when: _topocheckdomain.rc != 0
   changed_when: false
+  no_log: true
 
 - name: Check current ca topology
   ansible.builtin.command: |
@@ -35,3 +37,4 @@
     docker exec -t freeipa-app-1 /usr/bin/ipa topologysegment-add ca {{ freeipa_server_replica1 }}-to-{{ freeipa_server_replica2 }} --leftnode={{ freeipa_server_replica1 }} --rightnode={{ freeipa_server_replica2 }}
   when: _topocheckca.rc != 0
   changed_when: false
+  no_log: true

--- a/roles/freeipa/templates/docker-compose.yml
+++ b/roles/freeipa/templates/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     logging:
       driver: journald
       options:
-        tag: "freeipa"
+        tag: "freeipa-{{ freeipa_hostname }}"
     networks:
       - traefik_proxy
     dns: {{ freeipa_dns_servers }}
@@ -48,6 +48,7 @@ services:
 
     labels:
       traefik.enable: "{{ freeipa_traefik }}"
+{% if freeipa_traefik %}
       traefik.docker.network: "traefik_proxy"
 
       # https for realm clients, (ie. passthrough)
@@ -91,3 +92,4 @@ services:
       traefik.tcp.routers.ldapspt.tls.passthrough: "true"
       traefik.tcp.routers.ldapspt.service: "ldapspt"
       traefik.tcp.services.ldapspt.loadbalancer.server.port: "636"
+{% endif %}


### PR DESCRIPTION
- update freeipa image to 'freeipa-server:almalinux-9-4.11.0'
- update regexp in fixhttp.yml to match the changes from freeipa 4.11 vs 4.10
- make 'import tasks fixhttp.yml' conditional to 'freeipa_traefik'
- add 'no_log:true' to topologysegment.yml
- add freeipa_hostname to journald logging options.
- update README.md