### PR TITLE
Traefik

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -17,9 +17,9 @@ common_traefik_certresolver: none
 # how to set a provider from https://go-acme.github.io/lego/dns/
 # common_traefik_certresolver: mydomain
 
-# You can add Traefik ServersTransport using this.
-# https://doc.traefik.io/traefik/routing/services/#serverstransport_1
-# common_traefik_serversTransports: |
+# You can add Traefik configuration using file provider.
+# https://doc.traefik.io/traefik/providers/file/
+# common_traefik_file_provider: |
 #   http:
 #     serversTransports:
 #       mytransport:

--- a/roles/freeipa/defaults/main.yml
+++ b/roles/freeipa/defaults/main.yml
@@ -64,10 +64,9 @@ freeipa_ports:
   - "636:636/tcp"    # if your using traefik, open 636 in traefik container instead
 
 
-# serversTransports for connection between traefik proxy and freeipa service
-# freeipa forces https so traefik must accept freeipa's selfsigned
-# (or extract the rootCA from freeipa and add it to traefik maybe...?)
-common_traefik_serversTransports: |
+# Use file provider to add a serversTransports for connection between traefik proxy
+# and freeipa service. freeipa forces https so traefik must accept freeipa's selfsigned certificate.
+common_traefik_file_provider: |
   http:
     serversTransports:
       freeipa:

--- a/roles/freeipa/templates/docker-compose.yml
+++ b/roles/freeipa/templates/docker-compose.yml
@@ -67,7 +67,7 @@ services:
       traefik.http.services.freeipa.loadbalancer.server.port: "443"
       traefik.http.routers.freeipa.service: "freeipa"
       traefik.http.services.freeipa.loadbalancer.server.scheme: "https"
-{% if common_traefik_serversTransports is defined %}
+{% if common_traefik_file_provider is defined %}
       traefik.http.services.freeipa.loadbalancer.serverstransport: "freeipa@file"
 {% endif %}
 {% if common_traefik_tls and common_traefik_certresolver != "none" %}

--- a/roles/traefik/defaults/main.yml
+++ b/roles/traefik/defaults/main.yml
@@ -28,7 +28,7 @@ traefik_env_file: |
   TRAEFIK_ENTRYPOINTS_ldap_ADDRESS=:389
   TRAEFIK_ENTRYPOINTS_ldaps=true
   TRAEFIK_ENTRYPOINTS_ldaps_ADDRESS=:636
-  {% if common_traefik_serversTransports is defined %}
+  {% if common_traefik_file_provider is defined %}
   # file provider directory
   TRAEFIK_PROVIDERS_FILE_DIRECTORY=/etc/traefik
   {% endif %}

--- a/roles/traefik/defaults/main.yml
+++ b/roles/traefik/defaults/main.yml
@@ -81,3 +81,6 @@ traefik_certresolver_settings: ""
 #   EASYDNS_PROPAGATION_TIMEOUT=3600
 #   # The TTL of the TXT record used for the DNS challenge
 #   EASYDNS_TTL=3601
+
+# If you need additional traefik labels, you can add them here.
+# traefik_custom_labels: ""

--- a/roles/traefik/tasks/main.yml
+++ b/roles/traefik/tasks/main.yml
@@ -8,24 +8,24 @@
     path: "{{ docker_project_dir }}"
     state: directory
 
-- name: Copy docker-compose file
+- name: Copy docker-compose.yml
   ansible.builtin.template:
     src: docker-compose.yml
     dest: "{{ docker_project_dir }}/docker-compose.yml"
     mode: 0640
 
-- name: Create docker environment file
+- name: Copy traefik.env
   ansible.builtin.copy:
     dest: "{{ docker_project_dir }}/traefik.env"
     content: "{{ traefik_env_file }}"
     mode: 0640
   notify: Restart containers
 
-- name: Create traefik serverTransports file
+- name: Copy file_provider.yml
   ansible.builtin.copy:
-    dest: "{{ docker_project_dir }}/serversTransports.yml"
-    content: "{{ common_traefik_serversTransports }}"
-  when: common_traefik_serversTransports is defined
+    dest: "{{ docker_project_dir }}/file_provider.yml"
+    content: "{{ common_traefik_file_provider }}"
+  when: common_traefik_file_provider is defined
   notify: Restart containers
 
 - name: Import certificate.yml

--- a/roles/traefik/templates/docker-compose.yml
+++ b/roles/traefik/templates/docker-compose.yml
@@ -26,8 +26,8 @@ services:
       - "/etc/localtime:/etc/localtime:ro"
       - "/run/user/{{ docker_rootless_user.uid }}/docker.sock:/var/run/docker.sock"
       - "data:/data"
-{% if common_traefik_serversTransports is defined %}
-      - "./serversTransports.yml:/etc/traefik/serversTransports.yml"
+{% if common_traefik_file_provider is defined %}
+      - "./file_provider.yml:/etc/traefik/file_provider.yml"
 {% endif %}
 {% if common_traefik_certresolver == "none" %}
       - "./traefik-tls.yml:/etc/traefik/tls.yml"

--- a/roles/traefik/templates/docker-compose.yml
+++ b/roles/traefik/templates/docker-compose.yml
@@ -51,3 +51,7 @@ services:
       traefik.http.routers.traefik.tls.certresolver: "{{ common_traefik_certresolver }}"
       traefik.http.routers.traefik.tls.domains[0].main: "{{ inventory_hostname }}.{{ common_apps_domain }}"
 {% endif %}
+
+{% if traefik_custom_labels is defined %}
+      {{ traefik_custom_labels|indent(6) }}
+{% endif %}


### PR DESCRIPTION
rename traefik variable and file to a more appropriate name
for file provider.
- rename: common_traefik_serversTransports
      to: common_traefik_file_provider
- rename: serversTransports.yml
      to: file_provider.yml

add variable 'traefik_custom_labels'
