### PR TITLE
Mirrordeb

### DIFF
--- a/roles/mirrordeb/README.md
+++ b/roles/mirrordeb/README.md
@@ -5,7 +5,6 @@ This container downloads and maintains a partial local Debian/Ubuntu mirror usin
 - Update `defaults/main.yml` according to your needs. (and remove `--dry-run` option when all is set)
 - Distributions will be mirrored in the `mirrors` directory.
 - The `extras` directory is there for your locally build packages.
-  *(restart container to force update the Packages index file for the extras directory)*
 - The `keys` directory is for your own package signing keys.
 
 - https://manpages.org/debmirror
@@ -20,7 +19,7 @@ In addition to the nginx service, there are three other commands in this contain
 - `/run-extras-scanpackages.sh`, to build the `Packages.gz` for the `extras` directory.
 - `/run-signing-keys.sh`, to update the mirror signing keys.
 
-Define `dapp_mirrordeb_update_delay: 6h` to run theses commands every 6 hours,
+Define `dapp_mirrordeb_run_delay: 6h` to run theses commands every 6 hours,
 otherwise, you have to manually run theme:
 
 - `$ docker exec mirrordeb-app-1 /run-signing-keys.sh`

--- a/roles/mirrordeb/defaults/main.yml
+++ b/roles/mirrordeb/defaults/main.yml
@@ -5,9 +5,9 @@ dapp_mirrordeb_docker_image: "localbuild/mirrordeb"
 # service address
 dapp_mirrordeb_traefik_address: "mirror.{{ dapp_common_domain }}"
 
-# Delay between automatic mirror update.
-# No auto-update if not defined.
-# dapp_mirrordeb_update_delay: 6h
+# Define 'dapp_mirrordeb_run_delay' to execute commands
+# automatically according to the specified delay.
+# dapp_mirrordeb_run_delay: 6h
 
 # You can modify the following 'dapp_mirrordeb_directory_*' variables, but if you do,
 # you'll have to create the directories yourself; this role won't do it.
@@ -106,7 +106,7 @@ dapp_mirrordeb_dockerfile: |
 # container entrypoint.sh
 dapp_mirrordeb_entrypoint: |
   #!/bin/bash
-  {% if dapp_mirrordeb_update_delay is defined %}
+  {% if dapp_mirrordeb_run_delay is defined %}
   echo "starting nginx"
   nginx
   # Auto update mirror
@@ -115,7 +115,7 @@ dapp_mirrordeb_entrypoint: |
     /run-extras-scanpackages.sh
     /run-debmirror.sh
     echo "going to sleep ..."
-    sleep {{ dapp_mirrordeb_update_delay }}
+    sleep {{ dapp_mirrordeb_run_delay }}
   done
   {% else %}
   echo "starting nginx"


### PR DESCRIPTION
update the Dockerfile and scripts to execute commands manually or automatically according to a specified delay, using 'dapp_mirrordeb_run_delay'
