### PR TITLE
remove "/etc/localtime:/etc/localtime:ro" volume

### DIFF
--- a/roles/freeipa/templates/docker-compose.yml
+++ b/roles/freeipa/templates/docker-compose.yml
@@ -42,7 +42,6 @@ services:
       - "python:/usr/lib/python3.9/site-packages/ipaserver"
       - "/sys/fs/cgroup:/sys/fs/cgroup:ro"
       - "/sys/fs/cgroup/user.slice/user-{{ docker_rootless_user.uid }}.slice/user@{{ docker_rootless_user.uid }}.service:/sys/fs/cgroup/user.slice/user-{{ docker_rootless_user.uid }}.slice/user@{{ docker_rootless_user.uid }}.service:rw"
-      - "/etc/localtime:/etc/localtime:ro"
 {% if dapp_freeipa_cert is defined %}
       - "./freeipa_cert.crt:/etc/pki/CA/certs/freeipa_cert.crt:ro"
       - "./freeipa_cert.key:/etc/pki/CA/private/freeipa_cert.key:ro"

--- a/roles/gitlab/templates/docker-compose.yml
+++ b/roles/gitlab/templates/docker-compose.yml
@@ -28,7 +28,6 @@ services:
     healthcheck:
       {{ dapp_gitlab_docker_healthcheck|indent(6) }}
     volumes:
-      - "/etc/localtime:/etc/localtime:ro"
       - "config:/etc/gitlab"
       - "logs:/var/log/gitlab"
       - "data:/var/opt/gitlab"

--- a/roles/glances/templates/docker-compose.yml
+++ b/roles/glances/templates/docker-compose.yml
@@ -20,7 +20,6 @@ services:
     healthcheck:
       {{ dapp_glances_docker_healthcheck|indent(6) }}
     volumes:
-      - "/etc/localtime:/etc/localtime:ro"
       - "/run/user/{{ docker_rootless_user.uid }}/docker.sock:/var/run/docker.sock:ro" # ro for monitoring only
     pid: host
     labels:

--- a/roles/graylog/templates/docker-compose.yml
+++ b/roles/graylog/templates/docker-compose.yml
@@ -27,7 +27,6 @@ services:
     healthcheck:
       {{ dapp_graylog_mongo_docker_healthcheck|indent(6) }}
     volumes:
-      - "/etc/localtime:/etc/localtime:ro"
       {{ dapp_graylog_mongo_volumes|to_nice_yaml|indent(6) }}
     labels:
       traefik.enable: "false"
@@ -54,7 +53,6 @@ services:
         soft: 65536
         hard: 65536
     volumes:
-      - "/etc/localtime:/etc/localtime:ro"
       {{ dapp_graylog_opensearch_volumes|to_nice_yaml|indent(6) }}
     labels:
       traefik.enable: "false"
@@ -85,7 +83,6 @@ services:
         soft: 65536
         hard: 65536
     volumes:
-      - "/etc/localtime:/etc/localtime:ro"
       {{ dapp_graylog_volumes|to_nice_yaml|indent(6) }}
     labels:
       traefik.enable: "true"

--- a/roles/homepage/templates/docker-compose.yml
+++ b/roles/homepage/templates/docker-compose.yml
@@ -18,7 +18,6 @@ services:
     healthcheck:
       {{ dapp_homepage_docker_healthcheck|indent(6) }}
     volumes:
-      - "/etc/localtime:/etc/localtime:ro"
       - "./bookmarks.yaml:/app/config/bookmarks.yaml"
       - "./services.yaml:/app/config/services.yaml"
       - "./settings.yaml:/app/config/settings.yaml"

--- a/roles/mirrordeb/templates/docker-compose.yml
+++ b/roles/mirrordeb/templates/docker-compose.yml
@@ -23,7 +23,6 @@ services:
     healthcheck:
       {{ dapp_mirrordeb_docker_healthcheck|indent(6) }}
     volumes:
-      - "/etc/localtime:/etc/localtime:ro"
       - "homeroot:/root"
       - "{{ dapp_mirrordeb_directory_extras }}:/var/www/html/extras"
       - "{{ dapp_mirrordeb_directory_keys }}:/var/www/html/keys"

--- a/roles/monitoring/templates/docker-compose.yml
+++ b/roles/monitoring/templates/docker-compose.yml
@@ -23,7 +23,6 @@ services:
       - traefik_proxy
     mem_limit: {{ dapp_monitoring_prometheus_docker_mem_limit }}
     volumes:
-      - "/etc/localtime:/etc/localtime:ro"
       {{ dapp_monitoring_prometheus_volumes|to_nice_yaml|indent(6) }}
     environment:
       {{ dapp_monitoring_prometheus_docker_environment|indent(6) }}
@@ -64,7 +63,6 @@ services:
       - traefik_proxy
     mem_limit: {{ dapp_monitoring_alertmanager_docker_mem_limit }}
     volumes:
-      - "/etc/localtime:/etc/localtime:ro"
       {{ dapp_monitoring_alertmanager_volumes|to_nice_yaml|indent(6) }}
     environment:
       {{ dapp_monitoring_alertmanager_docker_environment|indent(6) }}
@@ -101,7 +99,6 @@ services:
       - traefik_proxy
     mem_limit: {{ dapp_monitoring_blackbox_docker_mem_limit }}
     volumes:
-      - "/etc/localtime:/etc/localtime:ro"
       {{ dapp_monitoring_blackbox_volumes|to_nice_yaml|indent(6) }}
     environment:
       {{ dapp_monitoring_blackbox_docker_environment|indent(6) }}
@@ -133,7 +130,6 @@ services:
       - traefik_proxy
     mem_limit: {{ dapp_monitoring_grafana_docker_mem_limit }}
     volumes:
-      - "/etc/localtime:/etc/localtime:ro"
       {{ dapp_monitoring_grafana_volumes|to_nice_yaml|indent(6) }}
 {% if dapp_monitoring_grafana_ldap_toml is defined %}
       - "./grafana_ldap.toml:/etc/grafana/ldap.toml"

--- a/roles/portainer/templates/docker-compose.yml
+++ b/roles/portainer/templates/docker-compose.yml
@@ -28,7 +28,6 @@ services:
     command: --admin-password="{{ dapp_portainer_admin_password_hash | regex_replace('\$','$$') }}"
 {% endif %}
     volumes:
-      - "/etc/localtime:/etc/localtime:ro"
       - "/run/user/{{ docker_rootless_user.uid }}/docker.sock:/var/run/docker.sock:ro"
       - "data:/data"
 {% if dapp_portainer_admin_password is defined %}

--- a/roles/privatebin/templates/docker-compose.yml
+++ b/roles/privatebin/templates/docker-compose.yml
@@ -19,8 +19,6 @@ services:
       {{ dapp_privatebin_docker_environment|indent(6) }}
     healthcheck:
       {{ dapp_privatebin_docker_healthcheck|indent(6) }}
-    volumes:
-      - "/etc/localtime:/etc/localtime:ro"
     labels:
       traefik.enable: "true"
       traefik.docker.network: "traefik_proxy"

--- a/roles/rsyslog/templates/docker-compose.yml
+++ b/roles/rsyslog/templates/docker-compose.yml
@@ -23,7 +23,6 @@ services:
     healthcheck:
       {{ dapp_rsyslog_docker_healthcheck|indent(6) }}
     volumes:
-      - "/etc/localtime:/etc/localtime:ro"
       - "./data:/data"
       - "./rsyslog.conf:/rsyslog.conf"
       - "./entrypoint.sh:/entrypoint.sh"

--- a/roles/traefik/templates/docker-compose.yml
+++ b/roles/traefik/templates/docker-compose.yml
@@ -24,7 +24,6 @@ services:
     healthcheck:
       {{ dapp_traefik_docker_healthcheck|indent(6) }}
     volumes:
-      - "/etc/localtime:/etc/localtime:ro"
       - "/run/user/{{ docker_rootless_user.uid }}/docker.sock:/var/run/docker.sock"
       - "data:/data"
 {% if dapp_common_traefik_file_provider is defined %}

--- a/roles/trivy/templates/docker-compose.yml
+++ b/roles/trivy/templates/docker-compose.yml
@@ -25,7 +25,6 @@ services:
     healthcheck:
       {{ dapp_trivy_docker_healthcheck|indent(6) }}
     volumes:
-      - "/etc/localtime:/etc/localtime:ro"
       - "cache:/root/.cache/trivy"
     command: server --listen 0.0.0.0:80 --token "{{ dapp_trivy_token }}"
     labels:


### PR DESCRIPTION
Delete the ‘/etc/localtime’ volume from all docker applications to avoid misconfiguration. The recommended method for configuring the time zone is to use the TZ environment variable. 